### PR TITLE
商品登録APIへのリクエストバリデーション機能の追加

### DIFF
--- a/handlers/products/post.py
+++ b/handlers/products/post.py
@@ -18,7 +18,6 @@ json_schema = {
     'required': [
         'name',
         'imageUrl',
-        'price',
         'description'
     ]
 }

--- a/handlers/products/post.py
+++ b/handlers/products/post.py
@@ -3,8 +3,25 @@ import os
 import boto3
 import uuid
 import time
+import jsonschema
 from lib.utils import response_builder
 from lib.decorators import api_handler
+
+json_schema = {
+    'type': 'object',
+    'properties': {
+        'name': {'type': 'string'},
+        'imageUrl': {'type': 'string'},
+        'price': {'type': 'string'},
+        'description': {'type': 'string'}
+    },
+    'required': [
+        'name',
+        'imageUrl',
+        'price',
+        'description'
+    ]
+}
 
 
 @api_handler
@@ -13,6 +30,9 @@ def handler(event, context):
     try:
         # リクエストBodyを取得
         body = event.get('body')
+
+        # リクエストデータのバリデーション
+        jsonschema.validate(body, json_schema)
 
         # 商品IDを生成
         id = str(uuid.uuid4())
@@ -52,6 +72,10 @@ def handler(event, context):
         # 商品の登録に成功してHTTPステータス201と商品IDをレスポンス
         return response_builder(201, {
             'product_id': id
+        })
+    except jsonschema.ValidationError as e:
+        return response_builder(400, {
+            'error_message': e.message
         })
     except Exception as e:
         raise e

--- a/handlers/products/post.py
+++ b/handlers/products/post.py
@@ -18,6 +18,7 @@ json_schema = {
     'required': [
         'name',
         'imageUrl',
+        'price',
         'description'
     ]
 }

--- a/tests/products/conftest.py
+++ b/tests/products/conftest.py
@@ -281,6 +281,7 @@ def missing_image_url_data():
         "isBase64Encoded": False
     }
 
+
 @pytest.fixture
 def missing_price_data():
     return {
@@ -347,6 +348,7 @@ def missing_price_data():
         "isBase64Encoded": False
     }
 
+
 @pytest.fixture
 def missing_description_data():
     return {
@@ -408,7 +410,7 @@ def missing_description_data():
         "body": {
             "name": "ヘルメット",
             "imageUrl": "http://example.com",
-             "price": "3000"
+            "price": "3000"
         },
         "isBase64Encoded": False
     }

--- a/tests/products/conftest.py
+++ b/tests/products/conftest.py
@@ -280,3 +280,135 @@ def missing_image_url_data():
         },
         "isBase64Encoded": False
     }
+
+@pytest.fixture
+def missing_price_data():
+    return {
+        "version": "2.0",
+        "routeKey": "POST /products",
+        "rawPath": "/products",
+        "rawQueryString": "",
+        "headers": {
+            "accept": "*/*",
+            "accept-encoding": "gzip, deflate, br",
+            "authorization": "Bearer eyJhbGciOiJ",
+            "content-length": "151",
+            "content-type": "application/json",
+            "host": "799dcg9vr4.execute-api.ap-northeast-1.amazonaws.com",
+            "postman-token": "1517b9b6-b3be-4eee-b077-e8631e4498d4",
+            "user-agent": "PostmanRuntime/7.28.4",
+            "x-amzn-trace-id": "Root=1-619271b9-6228738e52661cc90acb561b",
+            "x-forwarded-for": "61.194.146.83",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https"
+        },
+        "requestContext": {
+            "accountId": "825880940331",
+            "apiId": "799dcg9vr4",
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "aud": "rFJiMc4eRhQ9uXsbkcoT4LEIiYyUVWBo",
+                        "email": "horike@serverless.co.jp",
+                        "email_verified": "true",
+                        "exp": "1637023259",
+                        "iat": "1636987259",
+                        "iss": "https://product-api.jp.auth0.com/",
+                        "name": "horike@serverless.co.jp",
+                        "nickname": "horike",
+                        "nonce": "VW9TcGZkYX5Hd1JrUFZ5NkJFSEVSZ2pwTEUyYnY4WkpteFJNZC0ydjVvcg==",
+                        "picture": "https://s.gravatar.com/avatar/2ee9db3a5b6c492acf66ec14c8a5d8dc?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fho.png",
+                        "sub": "auth0|618dd25edf74f6006bd6de9e",
+                        "updated_at": "2021-11-15T14:40:58.196Z"
+                    },
+                    "scopes": None
+                }
+            },
+            "domainName": "799dcg9vr4.execute-api.ap-northeast-1.amazonaws.com",
+            "domainPrefix": "799dcg9vr4",
+            "http": {
+                "method": "POST",
+                "path": "/products",
+                "protocol": "HTTP/1.1",
+                "sourceIp": "61.194.146.83",
+                "userAgent": "PostmanRuntime/7.28.4"
+            },
+            "requestId": "I2a1BgZBNjMEJJw=",
+            "routeKey": "POST /products",
+            "stage": "$default",
+            "time": "15/Nov/2021:14:42:01 +0000",
+            "timeEpoch": 1636987321558
+        },
+        "body": {
+            "name": "ヘルメット",
+            "imageUrl": "http://example.com",
+            "description": "3"
+        },
+        "isBase64Encoded": False
+    }
+
+@pytest.fixture
+def missing_description_data():
+    return {
+        "version": "2.0",
+        "routeKey": "POST /products",
+        "rawPath": "/products",
+        "rawQueryString": "",
+        "headers": {
+            "accept": "*/*",
+            "accept-encoding": "gzip, deflate, br",
+            "authorization": "Bearer eyJhbGciOiJ",
+            "content-length": "151",
+            "content-type": "application/json",
+            "host": "799dcg9vr4.execute-api.ap-northeast-1.amazonaws.com",
+            "postman-token": "1517b9b6-b3be-4eee-b077-e8631e4498d4",
+            "user-agent": "PostmanRuntime/7.28.4",
+            "x-amzn-trace-id": "Root=1-619271b9-6228738e52661cc90acb561b",
+            "x-forwarded-for": "61.194.146.83",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https"
+        },
+        "requestContext": {
+            "accountId": "825880940331",
+            "apiId": "799dcg9vr4",
+            "authorizer": {
+                "jwt": {
+                    "claims": {
+                        "aud": "rFJiMc4eRhQ9uXsbkcoT4LEIiYyUVWBo",
+                        "email": "horike@serverless.co.jp",
+                        "email_verified": "true",
+                        "exp": "1637023259",
+                        "iat": "1636987259",
+                        "iss": "https://product-api.jp.auth0.com/",
+                        "name": "horike@serverless.co.jp",
+                        "nickname": "horike",
+                        "nonce": "VW9TcGZkYX5Hd1JrUFZ5NkJFSEVSZ2pwTEUyYnY4WkpteFJNZC0ydjVvcg==",
+                        "picture": "https://s.gravatar.com/avatar/2ee9db3a5b6c492acf66ec14c8a5d8dc?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fho.png",
+                        "sub": "auth0|618dd25edf74f6006bd6de9e",
+                        "updated_at": "2021-11-15T14:40:58.196Z"
+                    },
+                    "scopes": None
+                }
+            },
+            "domainName": "799dcg9vr4.execute-api.ap-northeast-1.amazonaws.com",
+            "domainPrefix": "799dcg9vr4",
+            "http": {
+                "method": "POST",
+                "path": "/products",
+                "protocol": "HTTP/1.1",
+                "sourceIp": "61.194.146.83",
+                "userAgent": "PostmanRuntime/7.28.4"
+            },
+            "requestId": "I2a1BgZBNjMEJJw=",
+            "routeKey": "POST /products",
+            "stage": "$default",
+            "time": "15/Nov/2021:14:42:01 +0000",
+            "timeEpoch": 1636987321558
+        },
+        "body": {
+            "name": "ヘルメット",
+            "imageUrl": "http://example.com",
+             "price": "3000"
+        },
+        "isBase64Encoded": False
+    }

--- a/tests/products/test_post.py
+++ b/tests/products/test_post.py
@@ -8,6 +8,30 @@ from lib.utils import parse_body
 class TestPostProducts(object):
     """新規商品追加のユニットテスト."""
 
+    def test_validation_body_missing_name(self, missing_name_data):
+        """Bodyのパラメータにnameが存在しない場合は400エラーを返す."""
+        result = post.handler(missing_name_data, {})
+        assert result.get('statusCode') == 400
+        assert result.get('body') == '{"error_message": "\'name\' is a required property"}'
+
+    def test_validation_body_missing_image_url(self, missing_image_url_data):
+        """BodyのパラメータにimageUrlが存在しない場合は400エラーを返す."""
+        result = post.handler(missing_image_url_data, {})
+        assert result.get('statusCode') == 400
+        assert result.get('body') == '{"error_message": "\'imageUrl\' is a required property"}'
+
+    def test_validation_body_missing_price(self, missing_price_data):
+        """Bodyのパラメータにpriceが存在しない場合は400エラーを返す."""
+        result = post.handler(missing_price_data, {})
+        assert result.get('statusCode') == 400
+        assert result.get('body') == '{"error_message": "\'price\' is a required property"}'
+
+    def test_validation_body_missing_description(self, missing_description_data):
+        """Bodyのパラメータにdescriptionが存在しない場合は400エラーを返す."""
+        result = post.handler(missing_description_data, {})
+        assert result.get('statusCode') == 400
+        assert result.get('body') == '{"error_message": "\'description\' is a required property"}'
+
     def test_correct_body(self, correct_input_data):
         """Bodyのパラメータが正常な場合はDBに登録しては201を返す."""
         result = post.handler(correct_input_data, {})

--- a/tests/products/test_post.py
+++ b/tests/products/test_post.py
@@ -20,12 +20,6 @@ class TestPostProducts(object):
         assert result.get('statusCode') == 400
         assert result.get('body') == '{"error_message": "\'imageUrl\' is a required property"}'
 
-    def test_validation_body_missing_price(self, missing_price_data):
-        """Bodyのパラメータにpriceが存在しない場合は400エラーを返す."""
-        result = post.handler(missing_price_data, {})
-        assert result.get('statusCode') == 400
-        assert result.get('body') == '{"error_message": "\'price\' is a required property"}'
-
     def test_validation_body_missing_description(self, missing_description_data):
         """Bodyのパラメータにdescriptionが存在しない場合は400エラーを返す."""
         result = post.handler(missing_description_data, {})

--- a/tests/products/test_post.py
+++ b/tests/products/test_post.py
@@ -20,6 +20,12 @@ class TestPostProducts(object):
         assert result.get('statusCode') == 400
         assert result.get('body') == '{"error_message": "\'imageUrl\' is a required property"}'
 
+    def test_validation_body_missing_price(self, missing_price_data):
+        """Bodyのパラメータにpriceが存在しない場合は400エラーを返す."""
+        result = post.handler(missing_price_data, {})
+        assert result.get('statusCode') == 400
+        assert result.get('body') == '{"error_message": "\'price\' is a required property"}'
+
     def test_validation_body_missing_description(self, missing_description_data):
         """Bodyのパラメータにdescriptionが存在しない場合は400エラーを返す."""
         result = post.handler(missing_description_data, {})


### PR DESCRIPTION
## 実装内容
商品登録APIのBodyパラメータに必須チェックを追加

## 実施したテスト
- [x] name属性がない時に400エラーがレスポンスとして返る
- [x] imageUrl属性がない時に400エラーがレスポンスとして返る
- [x] price属性がない時に400エラーがレスポンスとして返る
- [x] description属性がない時に400エラーがレスポンスとして返る
- [x] すべての属性が存在していれば、DBに登録されて201がレスポンスとして返る

## 関連issue 
#7 

## 影響範囲
商品登録API
